### PR TITLE
[Tests] [JSight to OpenAPI converter] req.japi.schema_notation.any_0.3 and req.japi.schema_notation.empty_0.3

### DIFF
--- a/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/any_notation_in_directive_body.jst
+++ b/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/any_notation_in_directive_body.jst
@@ -1,0 +1,19 @@
+JSIGHT 0.3
+
+# DIRECTIVE "Body": DIRECTIVE Request
+
+POST /notation/in/request/body/
+  Request
+    Body any
+
+POST /notation/in/request/no/body/directive
+  Request any
+
+# DIRECTIVE "Body": DIRECTIVES-RESPONSES
+
+GET /notation/in/response/body/
+  200
+    Body any
+
+GET /notation/in/response/no/body/directive/
+  200 any

--- a/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/any_notation_in_directive_body.openapi.todo
+++ b/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/any_notation_in_directive_body.openapi.todo
@@ -13,8 +13,11 @@
           }
         },
         "responses": {
-          "200": {
-            "description": ""
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       }
@@ -27,8 +30,11 @@
           }
         },
         "responses": {
-          "200": {
-            "description": ""
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       }

--- a/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/any_notation_in_directive_body.openapi.todo
+++ b/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/any_notation_in_directive_body.openapi.todo
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": ""
+  },
+  "paths": {
+    "/notation/in/request/body/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "*/*": {}
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/notation/in/request/no/body/directive": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "*/*": {}
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/notation/in/response/body/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "*/*": {}
+            }
+          }
+        }
+      }
+    },
+    "/notation/in/response/no/body/directive/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "*/*": {}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/empty_notation_in_directive_body.jst
+++ b/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/empty_notation_in_directive_body.jst
@@ -1,0 +1,19 @@
+JSIGHT 0.3
+
+# DIRECTIVE "Body": DIRECTIVE Request
+
+PUT /notation/in/request/body/
+  Request
+    Body empty
+
+PUT /notation/in/request/no/body/directive
+  Request empty
+
+# DIRECTIVE "Body": DIRECTIVES-RESPONSES
+
+PUT /notation/in/response/body/
+  200
+    Body empty
+
+PUT /notation/in/response/no/body/directive/
+  200 empty

--- a/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/empty_notation_in_directive_body.openapi.todo
+++ b/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/empty_notation_in_directive_body.openapi.todo
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": ""
+  },
+  "paths": {
+    "/notation/in/request/body/": {
+      "put": {
+        "requestBody": {
+          "content": {
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/notation/in/request/no/body/directive": {
+      "put": {
+        "requestBody": {
+          "content": {
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/notation/in/response/body/": {
+      "put": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+            }
+          }
+        }
+      }
+    },
+    "/notation/in/response/no/body/directive/": {
+      "put": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/empty_notation_in_directive_body.openapi.todo
+++ b/testdata/jsight_0.3/ser-to-openapi/req.japi.schema_notation/req.japi.schema_notation.any_empty_0.3/empty_notation_in_directive_body.openapi.todo
@@ -12,8 +12,11 @@
           }
         },
         "responses": {
-          "200": {
-            "description": ""
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       }
@@ -25,8 +28,11 @@
           }
         },
         "responses": {
-          "200": {
-            "description": ""
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {}
+            }
           }
         }
       }


### PR DESCRIPTION
## Changes
- New Functional Tests for OpenAPI Converter: "**req.japi.schema_notation.any_0.3**"
- New Functional Tests for OpenAPI Converter: "**req.japi.schema_notation.empty_0.3**"